### PR TITLE
Add new api features

### DIFF
--- a/marsbots-host/api_host.py
+++ b/marsbots-host/api_host.py
@@ -26,6 +26,11 @@ def get_robot_assignment():
     else:
         return {'status': 'fail', 'message': 'No available robots'}
 
+@app.route('/api/game_state', methods=['GET'])
+def get_game_state():
+    game_running, game_id = core.get_game_state()
+    return {'status': 'ok', 'game_running': game_running, 'game_id': game_id}
+
 
 @app.route('/api/sol', methods=['GET'])
 def get_sol():

--- a/marsbots-host/api_host.py
+++ b/marsbots-host/api_host.py
@@ -14,7 +14,7 @@ def home():
 <p>Learn more at <a href="https://sharedscience.org/">Shared Science</a>.</p>'''
 
 
-@app.route('/robot_assignment', methods=['GET'])
+@app.route('/api/robot_assignment', methods=['GET'])
 def get_robot_assignment():
     name = request.args.get('name')
     robot_number = core.assign_available_robot(name)
@@ -24,7 +24,7 @@ def get_robot_assignment():
         return {'status': 'fail', 'message': 'No available robots'}
 
 
-@app.route('/sol', methods=['GET'])
+@app.route('/api/sol', methods=['GET'])
 def get_sol():
     sol = core.get_sol()
     if sol:
@@ -32,7 +32,7 @@ def get_sol():
     return {'status': 'fail', 'message': 'Game not running'}
 
 
-@app.route('/plan', methods=['POST'])
+@app.route('/api/plan', methods=['POST'])
 def set_plan():
     form_robot = request.form.get('robot')
     if form_robot:

--- a/marsbots-host/api_host.py
+++ b/marsbots-host/api_host.py
@@ -13,11 +13,14 @@ def home():
     return '''<h1>Shared Science Marsbot Adventure</h1>
 <p>Learn more at <a href="https://sharedscience.org/">Shared Science</a>.</p>'''
 
-
 @app.route('/api/robot_assignment', methods=['GET'])
 def get_robot_assignment():
     name = request.args.get('name')
-    robot_number = core.assign_available_robot(name)
+    clientId = request.args.get('clientId')
+    if not name or not clientId:
+        return {'status': 'fail', 'message': 'Bad request'}
+
+    robot_number = core.get_user_robot(name, clientId)
     if robot_number:
         return {'status': 'ok', 'robot_number': robot_number}
     else:

--- a/marsbots-host/core.py
+++ b/marsbots-host/core.py
@@ -1,7 +1,14 @@
 import threading
 import time
 
-from remote_robot import RemoteRobot
+import os
+
+if 'MOCK_ROBOT' in os.environ and bool(os.environ['MOCK_ROBOT']):
+    from mock_robot import MockRobot
+    RobotClass = MockRobot
+else:
+    from remote_robot import RemoteRobot
+    RobotClass = RemoteRobot
 
 # Robot IDs
 #  id - Robot Number is the highly legible flag on the robot
@@ -40,7 +47,7 @@ _queue = []
 
 class _Robot:
     def __init__(self, rid):
-        self.robot = RemoteRobot(rid)
+        self.robot = RobotClass(rid)
         self.label = rid['name']
         self.name = None
         self.taken = False

--- a/marsbots-host/core.py
+++ b/marsbots-host/core.py
@@ -164,6 +164,8 @@ def abort_game():
     _game_running = False
     _game_id = uuid.uuid1()
 
+    release_all_robots()
+
 
 def is_game_running():
     return _game_running
@@ -233,6 +235,16 @@ def release_robot(number):
             robot.user = None
             robot.taken = False
 
+def release_all_robots():
+    with _lock:
+        rids = list(_user_robots.values())
+        for rid in rids:
+            robot = _robots.get(rid)
+            if not robot:
+                continue
+            del _user_robots[robot.user]
+            robot.user = None
+            robot.taken = False
 
 def get_taken(number):
     robot = _robots.get(number)

--- a/marsbots-host/core.py
+++ b/marsbots-host/core.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import uuid
 
 import os
 
@@ -39,6 +40,7 @@ _user_robots: 'dict[_User,str]' = {}
 
 # Game timer
 _game_running = False
+_game_id: str = uuid.uuid1()
 _sol_rt_base = 0.0
 
 # Thread safety
@@ -142,6 +144,9 @@ def get_player_name(number):
         return None
 
 
+def get_game_state():
+    return (_game_running, _game_id)
+
 def start_game():
     global _sol_rt_base, _game_running, _queue, _mins_per_sol, _delay_scale
     _sol_rt_base = time.time()
@@ -155,8 +160,9 @@ def start_game():
 
 
 def abort_game():
-    global _game_running
+    global _game_running, _game_id
     _game_running = False
+    _game_id = uuid.uuid1()
 
 
 def is_game_running():

--- a/marsbots-host/mock_robot.py
+++ b/marsbots-host/mock_robot.py
@@ -1,0 +1,29 @@
+class MockRobot:
+    def __init__(self, robot_info):
+        self.robot_ip_addr = None
+        self.robot_mac_addr = robot_info['btmac']
+        self.heard_ip_ad = False
+        self.s = None
+
+    def connect(self):
+        print('Connected to mock robot')
+        self.s = True
+
+    def heard_ad(self):
+        return self.heard_ip_ad
+
+    def is_connected(self):
+        return self.s is not None
+
+    def set_ip(self, addr):
+        self.robot_ip_addr = addr
+        self.heard_ip_ad = True
+        self.connect()
+
+    def close(self):
+        print('Disconnected from mock robot')
+        self.s = None
+
+    def send_command(self, command):
+        if self.s is not None:
+            print("Send data to mock robot:", str(command))


### PR DESCRIPTION
There are few changes in this PR:
1. I added a mock robot, so that we can test running the client against the actual server without needing actual robots. The mock robot is enabled by setting the `MOCK_ROBOT` environment variable to `True`
2. I added a the concept of a `game_id` and a method to query it. The `game_id` changes every time a game ends.
3. I updated the `/robot_assignment` route to require a user name and client id. It will associate new users with unassigned robots, and remember the association. Then, if the same user/client id queries the route again, it will return the already-assigned robot id.
4. I moved all the routes to be located under the `/api` route. This makes configuring the nginx server marginally easier, since we can just forward all `/api/*` queries to the server, instead of needing to match every possible method.