### PR TITLE
Update unmaintained dependencies

### DIFF
--- a/marsbots-host/control_gui.py
+++ b/marsbots-host/control_gui.py
@@ -1,4 +1,4 @@
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import core
 import get_public_ip
 import sound

--- a/marsbots-host/dev-requirements.txt
+++ b/marsbots-host/dev-requirements.txt
@@ -1,5 +1,4 @@
 simpleaudio
-pysimplegui==4.*
+FreeSimpleGUI==5.*
 flask
 requests
-

--- a/marsbots-host/dev-requirements.txt
+++ b/marsbots-host/dev-requirements.txt
@@ -1,4 +1,4 @@
-simpleaudio
+simpleaudio @ git+https://github.com/cexen/py-simple-audio@6a7cb95
 FreeSimpleGUI==5.*
 flask
 requests


### PR DESCRIPTION
Two of the four dependencies used by this project are no longer maintained.
This PR updates the `dev-requirements.txt` to point at (somewhat) maintained forks of these dependencies.

### PySimpleGUI
PySimpleGUI was taken closed-source in release 5, at which point the owner delisted all the previous releases from PyPI (what a jerk). [FreeSimpleGUI](https://github.com/spyoungtech/FreeSimpleGUI) is a fork that seems to be maintained.

### simpleaudio
simpleaudio was archived and development ceased in November 2021. In python v3.12, there was a change that causes simpleaudio to crash the whole python interpreter as soon as it finishes playing any sound (something related to memory allocation and the GIL, details here: hamiltron/py-simple-audio#72). The fork [cexen/py-simple-audio](https://github.com/cexen/py-simple-audio) fixes this issue.